### PR TITLE
fix: add about-title in the JSON files.

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -5,6 +5,7 @@
     "description": "Software Developer & Founder of CarreraIT"
   },
   "About": {
+    "about-title": "About Me",
     "introduction": "I'm Milena Sol Aron, a Software Developer from Argentina. I have been working in this field since June 2023.",
     "website": "This website serves as a place to write articles about the tech industry and also as a portfolio to showcase my personal projects.",
     "education": "I started my IT journey as a self-taught learner. In May 2024, I began pursuing an Associate's Degree in Programming at Universidad Tecnológica Nacional.",
@@ -15,7 +16,6 @@
     "about": "About",
     "resume": "Resume"
   },
-  "title": "About Me",
   "Resume": {
     "resume-title": "My Resume",
     "about-title": "About me",

--- a/messages/es.json
+++ b/messages/es.json
@@ -5,7 +5,7 @@
     "description": "Desarrolladora de software y fundadora de CarreraIT"
   },
   "About": {
-    "title": "Sobre mí",
+    "about-title": "Sobre mí",
     "introduction": "Soy Milena Sol Aron, una desarrolladora de software de Argentina. Estoy trabajando en el rubro desde junio de 2023.",
     "website": "Este sitio web es un espacio para escribir artículos relacionados con mi carrera y también como un portafolio para mostrar mis proyectos personales.",
     "education": "Comencé mis estudios de manera autodidacta. En mayo de 2024, empecé a estudiar una Tecnicatura en Programación en la Universidad Tecnológica Nacional.",

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -7,7 +7,7 @@ export default function About() {
   return (
     <section className="font-lato flex flex-col justify-center items-center p-4 min-h-screen bg-gradient-to-r from-orange-50 to-pink-100 text-pink-800">
     <h1 className="font-bold text-center text-4xl md:text-6xl m-8">
-    {t("title")}
+    {t("about-title")}
     </h1>
     <div className="space-y-6 max-w-2xl bg-white p-6 rounded-lg shadow-lg border-4 border-pink-400">
     <p className={paragraphClasses}>{t("introduction")}</p>


### PR DESCRIPTION
# Summary
In this branch, I added the about-title in the JSON files. In the case of the English locale, it was missing. In the Spanish one, it was named as `title`, which sounded vague to me. 