### PR TITLE
fix: Hydration Error

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -20,11 +20,13 @@ export const metadata: Metadata = {
 
 export default async function Layout({
   children,
-  params: { locale },
+  params,
 }: {
   children: React.ReactNode;
-  params: { locale: string };
+  params: Promise<{ locale: string }>;
 }) {
+  const { locale } = await params;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (!routing.locales.includes(locale as any)) {
     notFound();


### PR DESCRIPTION
# Summary
In order to fix the Hydration Error, I added an await for the locale params before using its properties. Luckily, this fixed the error very easily.

## Things done:
- Await the locale parameters before using their properties. 