### PR TITLE
refactor: Simplify the homepage's description.

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2,7 +2,7 @@
   "Homepage": {
     "welcome": "Welcome to my website!",
     "name": "I'm Milena Sol Aron",
-    "description": "Software Developer & Founder of CarreraIT"
+    "description": "Software Developer"
   },
   "About": {
     "about-title": "About Me",

--- a/messages/es.json
+++ b/messages/es.json
@@ -2,7 +2,7 @@
   "Homepage": {
     "welcome": "¡Bienvenido a mi sitio web!",
     "name": "Soy Milena Sol Aron",
-    "description": "Desarrolladora de software y fundadora de CarreraIT"
+    "description": "Desarrolladora de software"
   },
   "About": {
     "about-title": "Sobre mí",


### PR DESCRIPTION
# Summary
In this branch, I simplified the homepage description by removing CarreraIT's reference. I'm still working on that personal project, but I wanted to keep a simple way of describing myself.

## Things done:
- Removed CarreraIT's reference from the homepage's description.